### PR TITLE
Fix glucose compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ Other/Screenshots/Screen Shot 2017-10-03 at 12.27.48 PM.png
 Other/Screenshots/Screen Shot 2017-10-03 at 12.36.10 PM.png
 Other/Screenshots/Screen Shot 2017-10-03 at 12.42.52 PM.png
 Other/Puzzles/17.10.03.json.txt
+*.o
+depend.mk
+glucose

--- a/third_party/glucose-3.0/core/SolverTypes.h
+++ b/third_party/glucose-3.0/core/SolverTypes.h
@@ -55,7 +55,7 @@ struct Lit {
     int     x;
 
     // Use this as a constructor:
-    friend Lit mkLit(Var var, bool sign = false);
+    friend Lit mkLit(Var var, bool sign);
 
     bool operator == (Lit p) const { return x == p.x; }
     bool operator != (Lit p) const { return x != p.x; }
@@ -63,7 +63,7 @@ struct Lit {
 };
 
 
-inline  Lit  mkLit     (Var var, bool sign) { Lit p; p.x = var + var + (int)sign; return p; }
+inline  Lit  mkLit     (Var var, bool sign = false) { Lit p; p.x = var + var + (int)sign; return p; }
 inline  Lit  operator ~(Lit p)              { Lit q; q.x = p.x ^ 1; return q; }
 inline  Lit  operator ^(Lit p, bool b)      { Lit q; q.x = p.x ^ (unsigned int)b; return q; }
 inline  bool sign      (Lit p)              { return p.x & 1; }


### PR DESCRIPTION
Fix glucose compilation error

The default argument must not be in the friend declaration (at least with recent clang).

Also adds glucose compilation artifacts to .gitignore.
