### PR TITLE
Generate crossword constraint problem on commandline

### DIFF
--- a/third_party/glucose-3.0/mtl/template.mk
+++ b/third_party/glucose-3.0/mtl/template.mk
@@ -19,7 +19,7 @@ RCOBJS     = $(addsuffix r,  $(COBJS))
 
 #CXX        ?= /usr/gcc-/bin/g++-4.7.0
 CXX       ?= g++
-CFLAGS    ?= -Wall -Wno-parentheses
+CFLAGS    ?= -Wall -Wno-parentheses -std=c++11
 LFLAGS    ?= -Wall
 
 COPTIMIZE ?= -O3

--- a/third_party/glucose-3.0/simp/Main.cc
+++ b/third_party/glucose-3.0/simp/Main.cc
@@ -33,6 +33,10 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include <zlib.h>
 #include <sys/resource.h>
 
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <algorithm>
+
 #include "utils/System.h"
 #include "utils/ParseUtils.h"
 #include "utils/Options.h"
@@ -43,31 +47,451 @@ using namespace Glucose;
 
 //=================================================================================================
 
+char* readEntireFile(const char* filename, size_t *size_out) {
+    int fd = open(filename, O_RDONLY);
+    if (fd < 0) {
+        printf("error reading %s\n", filename);
+        exit(1);
+    }
+    struct stat statbuf;
+    fstat(fd, &statbuf);
+    size_t size = (size_t)statbuf.st_size;
+    //printf("file size = %d\n", (int)size);
+    *size_out = size;
+    char* result = new char[size];
+    read(fd, result, size);
+    close(fd);
+    return result;
+}
+
+class Wordlist {
+  public:
+    /* Note: the provided buffer must outlive the wordlist; we retain references into it */
+    void load(char* buf, size_t size) {
+        for (size_t i = 0; i < size;) {
+            size_t wordlen = 0;
+            while (i + wordlen < size && buf[i + wordlen] != '\n') {
+                wordlen++;
+            }
+            if (i + wordlen == size) break;  // partial line, shouldn't happen
+            while (words.size() <= wordlen) {
+                words.push();
+            }
+            // TODO: rejection of words containing non-alpha, conversion to uppercase
+            words[wordlen].push(buf + i);
+            i += wordlen + 1;
+        }
+    }
+
+    void get_matching(const char* pattern, size_t len, vec<char*>* result) {
+        result->clear();
+        if (len > words.size()) {
+            return;
+        }
+        vec<char*>& w = words[len];  // list of words of the given len
+        size_t i;
+        for (i = 0; i < len; i++) {
+            if (pattern[i] != ' ') break;
+        }
+        if (i == len) {
+            w.copyTo(*result);
+            return;
+        }
+        for (size_t j = 0; j < w.size(); j++) {
+            char* cand = w[j];
+            for (i = 0; i < len; i++) {
+                if (pattern[i] != ' ' && pattern[i] != cand[i]) break;
+            }
+            if (i == len) {
+                result->push(cand);
+            }
+        }
+    }
+  private:
+    vec<vec<char*> > words;
+};
+
+class Coord {
+  public:
+    Coord(int x, int y) : x(x), y(y) { }
+    int x, y;
+};
+
+class Word {
+  public:
+    vec<Coord> locs;
+    size_t filled_count;
+    size_t dist;
+};
+
+bool char_in_str(char c, const char* s, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        if (s[i] == c) return true;
+    }
+    return false;
+}
+
+class Grid {
+  public:
+    void load(char* buf, size_t size) {
+        data = buf;
+        for (size_t i = 0; i < size;) {
+            size_t linelen = 0;
+            while (i + linelen < size && buf[i + linelen] != '\n') {
+                linelen++;
+            }
+            if (i + linelen == size) break;  // partial line, shouldn't happen
+            cols = linelen;
+            rows++;
+            i += linelen + 1;
+        }
+        across.growTo(cols * rows, -1);
+        down.growTo(cols * rows, -1);
+    }
+
+    /* Analyzes the grid for words */
+    void analyze() {
+        for (int y = 0; y < rows; y++) {
+            for (int x = 0; x < cols; x++) {
+                if (get(x, y) != '.') {
+                    if (x == 0 || get(x - 1, y) == '.') {
+                        int end = x + 1;
+                        while (end < cols && get(end, y) != '.') end++;
+                        vec<Coord> locs;
+                        for (int xx = x; xx < end; xx++) {
+                            locs.push(Coord(xx, y));
+                        }
+                        add_word(locs, false);
+                    }
+                    if (y == 0 || get(x, y - 1) == '.') {
+                        int end = y + 1;
+                        while (end < rows && get(x, end) != '.') end++;
+                        vec<Coord> locs;
+                        for (int yy = y; yy < end; yy++) {
+                            locs.push(Coord(x, yy));
+                        }
+                        add_word(locs, true);
+                    }
+                }
+            }
+        }
+    }
+
+    void add_word(vec<Coord>& locs, bool is_down) {
+        int w_ix = (int)words.size();
+        words.push();
+        Word& w = words.last();
+        w.filled_count = 0;
+        for (size_t i = 0; i < locs.size(); i++) {
+            Coord c = locs[i];
+            if (get(c.x, c.y) != ' ') {
+                w.filled_count++;
+            }
+            if (is_down) {
+                down[c.y * cols + c.x] = w_ix;
+            } else {
+                across[c.y * cols + c.x] = w_ix;
+            }
+        }
+        w.dist = w.filled_count != 0 ? 0 : 9999;
+        locs.moveTo(w.locs);
+    }
+
+    // Compute distance from partially or fully filled word for each word in grid
+    void bfs() {
+        vec<int> q;
+        for (size_t i = 0; i < words.size(); i++) {
+            if (words[i].dist == 0) {
+                q.push(i);
+            }
+        }
+        // Note: if q is empty, then grid consists only of unfilled words
+        size_t ix = 0;
+        while (ix < q.size()) {
+            Word& w = words[q[ix++]];
+            size_t dist = w.dist + 1;
+            for (size_t j = 0; j < w.locs.size(); j++) {
+                Coord loc = w.locs[j];
+                size_t loc_ix = loc.y * cols + loc.x;
+                if (dist < words[across[loc_ix]].dist) {
+                    words[across[loc_ix]].dist = dist;
+                    q.push(across[loc_ix]);
+                }
+                if (dist < words[down[loc_ix]].dist) {
+                    words[down[loc_ix]].dist = dist;
+                    q.push(down[loc_ix]);
+                }
+            }
+        }
+    }
+
+    // max distance of all words in the grid
+    size_t max_dist() const {
+        size_t result = 0;
+        for (size_t i = 0; i < words.size(); i++) {
+            result = std::max(result, words[i].dist);
+        }
+        return result;
+    }
+
+    size_t dist_of_loc(Coord loc) const {
+        size_t ix = loc.y * cols + loc.x;
+        return std::min(words[across[ix]].dist, words[down[ix]].dist);
+    }
+
+    // reject words with uncommon letters in high-distance locations
+    bool check_freq_constraint(vec<Coord>& locs, const char* word,
+        int thresh1, int thresh2) const
+    {
+        const char *freq = "ETAOINSHRDLCUMWFGYPBVKJXQZ";
+        for (size_t i = 0; i < locs.size(); i++) {
+            if (dist_of_loc(locs[i]) == 1) {
+                if (!char_in_str(word[i], freq, thresh1)) return false;
+            } else if (dist_of_loc(locs[i]) >= 2) {
+                if (!char_in_str(word[i], freq, thresh2)) return false;
+            }
+        }
+        return true;
+    }
+
+    const char& operator [] (Coord c) const {
+        return data[c.y * (cols + 1) + c.x];
+    }
+    char& operator [] (Coord c) {
+        return data[c.y * (cols + 1) + c.x];
+    }
+    char get(int x, int y) {
+        return data[y * (cols + 1) + x];
+    }
+    size_t cols = 0;
+    size_t rows = 0;
+    vec<Word> words;
+  private:
+    char* data;
+    vec<int> across;  // index of across word at each loc
+    vec<int> down;    // index of down word at each loc
+};
+
+void printStats(Solver& solver);
+
+// Core fill algorithm; use 10000 for max_dist and max_recon to solve entire grid
+// Return value is 0 on success, 20 if unsat
+int fill_core(Wordlist& wl, char* puz, size_t puz_size, bool pre, int max_dist, int max_recon,
+        int thresh1, int thresh2)
+{
+    Grid g;
+    g.load(puz, puz_size);
+    g.analyze();
+    SimpSolver S;
+    S.parsing = 1;
+    if (!pre) {
+        // Note: this interface changes with glucose 4
+        S.eliminate(true);
+    }
+
+    /* create letter variables and "at most one" constraints */
+    vec<int> letter_base;
+    int v = 0;
+    for (size_t y = 0; y < g.rows; y++) {
+        for (size_t x = 0; x < g.cols; x++) {
+            char c = g.get(x, y);
+            if (c == ' ') {
+                letter_base.push(v);
+                for (int i = 0; i < 26; i++) {
+                    S.newVar();
+                }
+                for (int i = 0; i < 25; i++) {
+                    for (int j = i + 1; j < 26; j++) {
+                        S.addClause(~mkLit(v + i), ~mkLit(v + j));
+                    }
+                }
+                v += 26;
+            } else {
+                letter_base.push(-1);
+            }
+        }
+    }
+
+    g.bfs();
+    size_t g_max_dist = g.max_dist();
+    printf("max dist = %d\n", (int)g_max_dist);
+    if (g_max_dist == 9999) {
+        // empty grid
+        max_dist = 10000;
+    }
+    if (g_max_dist < max_dist) {
+        max_recon = 10000;
+    }
+
+    /* create word variables, word->letter constraints, and "at least one" constraints */
+    const size_t MAX_WORD = 128;
+    char pattern[MAX_WORD];
+    vec<char*> matches;
+    vec<Lit> lits; // used for building "at least one" word constraint
+    assert(g.cols <= MAX_WORD && g.rows <= MAX_WORD);
+    for (size_t i = 0; i < g.words.size(); i++) {
+        Word& w = g.words[i];
+        if (w.dist >= max_dist) continue;
+        size_t len = w.locs.size();
+        if (w.filled_count == len) continue;
+        for (size_t j = 0; j < len; j++) {
+            pattern[j] = g[w.locs[j]];
+        }
+        wl.get_matching(pattern, len, &matches);
+        lits.clear();
+        for (size_t j = 0; j < matches.size(); j++) {
+            char* match = matches[j];
+            if (!g.check_freq_constraint(w.locs, match, thresh1, thresh2)) continue;
+            //printf("%.*s\n", len, matches[j]);
+            S.newVar();
+            lits.push(mkLit(v));
+            for (size_t k = 0; k < len; k++) {
+                Coord loc = w.locs[k];
+                int base = letter_base[loc.y * g.cols + loc.x];
+                if (base >= 0) {
+                    S.addClause(~mkLit(v), mkLit(base + match[k] - 'A'));
+                }
+            }
+            v++;
+        }
+        S.addClause_(lits);
+    }
+
+    /* solve and output */
+    S.parsing = 0;
+    S.verbosity = 0;
+    S.verbEveryConflicts = 10000;
+    S.showModel = false;
+       if (S.verbosity > 0){
+            printf("c |  Number of variables:  %12d                                                                   |\n", S.nVars());
+            printf("c |  Number of clauses:    %12d                                                                   |\n", S.nClauses()); }
+    //S.toDimacs("/tmp/dimacs");
+    S.eliminate(true);
+    vec<Lit> dummy;
+    lbool ret = S.solveLimited(dummy);
+    if (S.verbosity >= 1) {
+        printStats(S);
+    }
+    size_t ix = 0;
+    if (ret == l_True) {
+        for (size_t y = 0; y < g.rows; y++) {
+            for (size_t x = 0; x < g.cols; x++) {
+                int base = letter_base[ix++];
+                if (base >= 0 && g.dist_of_loc(Coord(x, y)) < max_recon) {
+                    for (int z = 0; z < 26; z++) {
+                        if (S.model[base + z] == l_True) {
+                            puz[y * (g.cols + 1) + x] = 'A' + z;
+                        }
+                    }
+                }
+            }
+        }
+        return 0;
+    } else {
+        printf("UNSAT\n");
+        return 20;
+    }
+}
+
+// Iterate the fill core until grid is filled
+int fill_iterative(Wordlist& wl, char* puz, size_t puz_size, bool pre,
+        int thresh1, int thresh2)
+{
+    vec<char> save_puz(puz_size);
+    memcpy(save_puz, puz, puz_size);
+    int max_dist = 2;
+
+    size_t iter = 0;
+    while (true) {
+        size_t i;
+        for (i = 0; i < puz_size; i++) {
+            if (puz[i] == ' ') break;
+        }
+        if (i == puz_size) {
+            // successful fill
+            return 0;
+        }
+        int status = fill_core(wl, puz, puz_size, pre, max_dist, 1, thresh1, thresh2);
+        if (status != 0) {
+            if (iter == 0) return status;
+            // Got into a dead end, try a deeper initial search
+            max_dist++;
+            printf("restarting, max_dist = %d\n", max_dist);
+            memcpy(puz, save_puz, puz_size);
+            iter = 0;
+        } else {
+            iter++;
+        }
+    }
+}
+
+int main(int argc, char** argv) {
+    IntOption    cpu_lim("MAIN", "cpu-lim","Limit on CPU time allowed in seconds.\n", INT32_MAX, IntRange(0, INT32_MAX));
+    BoolOption   pre    ("MAIN", "pre",    "Completely turn on/off any preprocessing.", false);
+    IntOption    thresh1("MAIN", "thresh1","Letter frequency threshold for distance 1", 26, IntRange(0, 26));
+    IntOption    thresh2("MAIN", "thresh2","Letter frequency threshold for distance >=2", 26, IntRange(0, 26));
+
+    // this is needed to set the defaults
+    parseOptions(argc, argv, true);
+
+        // Set limit on CPU-time:
+    if (cpu_lim != INT32_MAX){
+        rlimit rl;
+        getrlimit(RLIMIT_CPU, &rl);
+        if (rl.rlim_max == RLIM_INFINITY || (rlim_t)cpu_lim < rl.rlim_max){
+            rl.rlim_cur = cpu_lim;
+            if (setrlimit(RLIMIT_CPU, &rl) == -1)
+                printf("c WARNING! Could not set resource limit: CPU-time.\n");
+        } }
+
+    if (argc < 3) {
+        printf("usage: glucose wordlist puzzle\n");
+        exit(1);
+    }
+    char* wl_fn = argv[1];
+    char* puz_fn = argv[2];
+
+    size_t wl_size;
+    char* words = readEntireFile(wl_fn, &wl_size);
+    Wordlist wl;
+    wl.load(words, wl_size);
+    size_t puz_size;
+    char* puz = readEntireFile(puz_fn, &puz_size);
+    int result = fill_iterative(wl, puz, puz_size, pre, thresh1, thresh2);
+    if (result == 0) {
+        int o_fd = open(puz_fn, O_WRONLY | O_TRUNC);
+        if (o_fd >= 0) {
+            write(o_fd, puz, puz_size);
+        }
+    }
+    return result;
+}
 
 void printStats(Solver& solver)
 {
     double cpu_time = cpuTime();
     double mem_used = 0;//memUsedPeak();
-    printf("c restarts              : %"PRIu64" (%"PRIu64" conflicts in avg)\n", solver.starts,(solver.starts>0 ?solver.conflicts/solver.starts : 0));
-    printf("c blocked restarts      : %"PRIu64" (multiple: %"PRIu64") \n", solver.nbstopsrestarts,solver.nbstopsrestartssame);
-    printf("c last block at restart : %"PRIu64"\n",solver.lastblockatrestart);
+    printf("c restarts              : %" PRIu64 " (%" PRIu64 " conflicts in avg)\n", solver.starts,(solver.starts>0 ?solver.conflicts/solver.starts : 0));
+    printf("c blocked restarts      : %" PRIu64 " (multiple: %" PRIu64 ") \n", solver.nbstopsrestarts,solver.nbstopsrestartssame);
+    printf("c last block at restart : %" PRIu64 "\n",solver.lastblockatrestart);
     printf("c nb ReduceDB           : %lld\n", solver.nbReduceDB);
     printf("c nb removed Clauses    : %lld\n",solver.nbRemovedClauses);
     printf("c nb learnts DL2        : %lld\n", solver.nbDL2);
     printf("c nb learnts size 2     : %lld\n", solver.nbBin);
     printf("c nb learnts size 1     : %lld\n", solver.nbUn);
 
-    printf("c conflicts             : %-12"PRIu64"   (%.0f /sec)\n", solver.conflicts   , solver.conflicts   /cpu_time);
-    printf("c decisions             : %-12"PRIu64"   (%4.2f %% random) (%.0f /sec)\n", solver.decisions, (float)solver.rnd_decisions*100 / (float)solver.decisions, solver.decisions   /cpu_time);
-    printf("c propagations          : %-12"PRIu64"   (%.0f /sec)\n", solver.propagations, solver.propagations/cpu_time);
-    printf("c conflict literals     : %-12"PRIu64"   (%4.2f %% deleted)\n", solver.tot_literals, (solver.max_literals - solver.tot_literals)*100 / (double)solver.max_literals);
+    printf("c conflicts             : %-12" PRIu64 "   (%.0f /sec)\n", solver.conflicts   , solver.conflicts   /cpu_time);
+    printf("c decisions             : %-12" PRIu64 "   (%4.2f %% random) (%.0f /sec)\n", solver.decisions, (float)solver.rnd_decisions*100 / (float)solver.decisions, solver.decisions   /cpu_time);
+    printf("c propagations          : %-12" PRIu64 "   (%.0f /sec)\n", solver.propagations, solver.propagations/cpu_time);
+    printf("c conflict literals     : %-12" PRIu64 "   (%4.2f %% deleted)\n", solver.tot_literals, (solver.max_literals - solver.tot_literals)*100 / (double)solver.max_literals);
     printf("c nb reduced Clauses    : %lld\n",solver.nbReducedClauses);
     
     if (mem_used != 0) printf("Memory used           : %.2f MB\n", mem_used);
     printf("c CPU time              : %g s\n", cpu_time);
 }
 
-
+// Standard main for glucose is #if'ed out, this version is specialized for crosswords
+#if 0
 
 static Solver* solver;
 // Terminate by notifying the solver and back out gracefully. This is mainly to have a test-case
@@ -249,3 +673,5 @@ int main(int argc, char** argv)
         exit(0);
     }
 }
+
+#endif

--- a/third_party/glucose-3.0/utils/Options.h
+++ b/third_party/glucose-3.0/utils/Options.h
@@ -282,15 +282,15 @@ class Int64Option : public Option
         if (range.begin == INT64_MIN)
             fprintf(stderr, "imin");
         else
-            fprintf(stderr, "%4"PRIi64, range.begin);
+            fprintf(stderr, "%4" PRIi64, range.begin);
 
         fprintf(stderr, " .. ");
         if (range.end == INT64_MAX)
             fprintf(stderr, "imax");
         else
-            fprintf(stderr, "%4"PRIi64, range.end);
+            fprintf(stderr, "%4" PRIi64, range.end);
 
-        fprintf(stderr, "] (default: %"PRIi64")\n", value);
+        fprintf(stderr, "] (default: %" PRIi64")\n", value);
         if (verbose){
             fprintf(stderr, "\n        %s\n", description);
             fprintf(stderr, "\n");


### PR DESCRIPTION
This commit replaces the DIMACS parsing in glucose with logic to
synthesize CNF clauses from a crossword problem. The wordlist and grid
(in plain ASCII format) are command line arguments.

The solver uses sophisticated techniques to try to narrow the search
space, for faster solving. In addition, it constrains the letter
choices of "distant" cells to popular letters, as a command line
option.